### PR TITLE
fix: harmonize response across single and cluster

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ module.exports = function configure (url, source, callback) {
             const configTasks = result.all_nodes.map((node) => {
               return writeConfig.bind(null, `_node/${node}/_config/`)
             })
-            return async.series(configTasks, done)
+            return async.series(configTasks, function (error, responses) {
+              done(error, responses[0])
+            })
           }
         })
       } else {


### PR DESCRIPTION
for the cluster the response perviously has been an array of each individual nodes responses. Now, return just the first one.

Maybe this is not the best thing to do and we should return each nodes individual response, or throw if they differ. But I think its fine for now, we can iterate as needed.